### PR TITLE
(hybris) Ignore permission check for user nemo

### DIFF
--- a/libs/binder/IServiceManager.cpp
+++ b/libs/binder/IServiceManager.cpp
@@ -72,6 +72,14 @@ bool checkPermission(const String16& permission, pid_t pid, uid_t uid)
     return true;
 #endif
 
+    // For Mer
+    //For devices rendering with surfaceflinger, the ACCESS_SURFACE_FLINGER permission
+    //check for user nemo(uid = 100000) is ignored.
+    if (uid == 100000 && (permission == String16("android.permission.ACCESS_SURFACE_FLINGER"))) {
+        ALOGI("Mer: Enabled permission for user nemo. uid=%d  pid=%d", uid, pid);
+        return true;
+    }
+
     sp<IPermissionController> pc;
     gDefaultServiceManagerLock.lock();
     pc = gPermissionController;

--- a/libs/binder/PermissionCache.cpp
+++ b/libs/binder/PermissionCache.cpp
@@ -95,6 +95,12 @@ bool PermissionCache::checkPermission(
         return true;
     }
 
+    // For Mer: uid 100000 is user nemo.
+    if (uid == 100000 && (permission == String16("android.permission.ACCESS_SURFACE_FLINGER"))) {
+         ALOGI("Mer: Enabled permission for user nemo. uid=%d  pid=%d", uid, pid);
+         return true;
+     }
+
     PermissionCache& pc(PermissionCache::getInstance());
     bool granted = false;
     if (pc.check(&granted, permission, uid) != NO_ERROR) {


### PR DESCRIPTION
For devices rendering with surfaceflinger to fix this error:
"E SurfaceFlinger: Permission Denial: can't access SurfaceFlinger
pid=2822, uid=100000"

Change-Id: If52aa225b83502d19155cd2835abbcf55d3b625f